### PR TITLE
DHHDP-920 Add VITALA to the enum Nodenames

### DIFF
--- a/dhhdpetlutils/core/enums.py
+++ b/dhhdpetlutils/core/enums.py
@@ -19,3 +19,4 @@ class Nodenames(ExtendedStrEnum):
     MUMC = "mumc"
     ZIO = "zio"
     ENVIDA = "envida"
+    VITALA = "vitala"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dhhdpetlutils"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
   { name="DataHub Maastricht" },
 ]


### PR DESCRIPTION
Bump version to 0.3.0
[DHHDP-920, DHHDP-957]